### PR TITLE
fix:#18 Fixed an error when calling this.jspdfCtx.restoreGraphicsState() when the internal graphics state stack of jsPDF is empty

### DIFF
--- a/src/render/canvas/pdf-renderer.ts
+++ b/src/render/canvas/pdf-renderer.ts
@@ -910,6 +910,11 @@ export class CanvasRenderer extends Renderer {
         curvePoints: BoundCurves,
         style: BORDER_STYLE
     ): Promise<void> {
+         /**
+         * fix: Fixed an error when calling this.jspdfCtx.restoreGraphicsState() when the internal graphics state stack of jsPDF is empty
+         * Save the jsPDF graphics state first
+         */
+        this.jspdfCtx.saveGraphicsState();
         this.context2dCtx.save();
 
         const strokePaths = parsePathForBorderStroke(curvePoints, side);


### PR DESCRIPTION
### 修复的问题
- 关联 Issues：[#18](https://github.com/lmn1919/dompdf.js/issues/18)
- Bug 现象：导出PDF 包含 border dashed样式时报错：Uncaught (in promise) TypeError: Cannot read properties of unndefined (reading 'key')