### PR TITLE
fix:#17 jspdf encryption default value

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -9,6 +9,7 @@ import {ForeignObjectRenderer} from './render/canvas/foreignobject-renderer';
 import {CanvasRenderer, RenderConfigurations, RenderOptions} from './render/canvas/pdf-renderer';
 import {PAGE_FORMAT_MAP} from './render/page-format-map';
 import {paginateNode} from './render/paginate';
+import {isEmptyValue} from './utils/index';
 // paginationState
 
 interface FontConfig {
@@ -158,11 +159,7 @@ const renderElement = async (element: HTMLElement, opts: Partial<Options>): Prom
             fontFamily: '',
             fontBase64: ''
         },
-        encryption: {
-            userPassword: '',
-            ownerPassword: '',
-            userPermissions: []
-        },
+        encryption: isEmptyValue(opts.encryption) ? undefined : opts.encryption, // fix：jspdf encryption default value
         precision: opts.precision ?? 16,
         floatPrecision: opts.floatPrecision ?? 16,
         compress: opts.compress ?? false,

--- a/src/render/canvas/pdf-renderer.ts
+++ b/src/render/canvas/pdf-renderer.ts
@@ -1,4 +1,4 @@
-import {jsPDF} from 'jspdf';
+import {jsPDF, EncryptionOptions} from 'jspdf';
 import {contains} from '../../core/bitwise';
 import {Context} from '../../core/context';
 import {CSSParsedDeclaration} from '../../css';
@@ -95,6 +95,12 @@ export type pageConfigOptions = {
     };
 };
 
+// export interface EncryptionOptions {
+//     userPassword?: string;
+//     ownerPassword?: string;
+//     userPermissions?: ("print" | "modify" | "copy" | "annot-forms")[];
+// }
+
 export interface RenderOptions {
     scale: number;
     canvas?: HTMLCanvasElement;
@@ -103,11 +109,7 @@ export interface RenderOptions {
     width: number;
     height: number;
     pdfFileName?: string;
-    encryption?: {
-        userPassword?: string;
-        ownerPassword?: string;
-        userPermissions?: string[];
-    };
+    encryption?: EncryptionOptions | undefined;
     precision?: number;
     floatPrecision?: number | 'smart';
     compress?: boolean;
@@ -176,26 +178,6 @@ export class CanvasRenderer extends Renderer {
         const pageWidth = pxToPt(options.width);
         const pageHeight = pxToPt(options.height);
 
-        // const enc =
-        //     this.options.encryption &&
-        //     (this.options.encryption.userPassword ||
-        //         this.options.encryption.ownerPassword ||
-        //         (this.options.encryption.userPermissions && this.options.encryption.userPermissions.length))
-        //         ? this.options.encryption
-        //         : [];
-        const encOptions = this.options.encryption
-            ? {
-                  userPassword: this.options.encryption.userPassword,
-                  ownerPassword: this.options.encryption.ownerPassword,
-                  userPermissions: this.options.encryption.userPermissions as (
-                      | 'print'
-                      | 'modify'
-                      | 'copy'
-                      | 'annot-forms'
-                  )[]
-              }
-            : undefined;
-
         this.jspdfCtx = new jsPDF({
             orientation: pageWidth > pageHeight ? 'landscape' : 'portrait',
             unit: 'pt',
@@ -205,18 +187,8 @@ export class CanvasRenderer extends Renderer {
             compress: options.compress,
             precision: options.precision,
             floatPrecision: options.floatPrecision,
-            encryption: encOptions
+            encryption: options.encryption
         });
-        //     orientation: pageWidth > pageHeight ? 'landscape' : 'portrait',
-        //     unit: 'pt',
-        //     format: options.pagination && options.format ? options.format : [pageHeight, pageWidth],
-        //     hotfixes: ['px_scaling'],
-        //     putOnlyUsedFonts: options.putOnlyUsedFonts,
-        //     compress: options.compress,
-        //     precision: options.precision,
-        //     floatPrecision: options.floatPrecision,
-        //     encryption: enc
-        // });
         this.context2dCtx = this.jspdfCtx.context2d;
         this.context2dCtx.scale(0.75, 0.75);
 

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,0 +1,25 @@
+export function isEmptyValue(obj: any): Boolean {
+  if (obj === undefined) {
+    return true
+  } else if (obj === null) {
+    return true
+  } else if (obj === false) {
+    return true
+  } else if (obj === '') {
+    return true
+  } else if (isArray(obj) && obj.length === 0) {
+    return true
+  } else if (isObject(obj) && JSON.stringify(obj) === '{}') {
+    return true
+  } else {
+    return false
+  }
+}
+
+export function isArray(obj: any): Boolean {
+  return Object.prototype.toString.call(obj) === '[object Array]'
+}
+
+export function isObject(obj: any): Boolean {
+  return Object.prototype.toString.call(obj) === '[object Object]'
+}


### PR DESCRIPTION
### 修复的问题
- 关联 Issues：[#17](https://github.com/lmn1919/dompdf.js/issues/17)
- Bug 现象：导出PDF wps显示有已加密字样
- Bug 原因：jspdf  encryption 是可组合的参数，只要encryption就会显示已加密