### PR TITLE
feat: add PDF hyperlink annotations

### DIFF
--- a/src/snapshot.ts
+++ b/src/snapshot.ts
@@ -568,6 +568,7 @@ interface NodeRec {
   renderMode: number;
   divisionDisable: boolean;
   pageBreak: boolean;
+  href?: string;
   text?: string;
   lines?: LineBox[];
 }
@@ -584,6 +585,8 @@ const F_RENDER_MODE = 0x80;
 const F_DIVISION_DISABLE = 0x100;
 const F_PAGE_BREAK = 0x200;
 const F_SHADOW = 0x400;
+const F_LINK = 0x800;
+const F_AVOID_IMAGE_SPLIT = 0x1000;
 
 // header/footer position enum (must match Rust HFSpec.position)
 function positionNum(p: ContentPosition | undefined): number {
@@ -2406,6 +2409,9 @@ function buildInlineRunsWithLangFont(
     // re-measuring now — see the comment by imgRectAtConvert above.
     const rawRect = (isImg && imgRectAtConvert.get(el)) || el.getBoundingClientRect();
     const r = docRect(rawRect);
+    const hrefAttr = el.tagName === 'A' ? el.getAttribute('href')?.trim() : '';
+    const resolvedHref = hrefAttr ? (el as HTMLAnchorElement).href.trim() : '';
+    const href = resolvedHref && !/^javascript:/i.test(resolvedHref) ? resolvedHref : undefined;
 
     const kind = isImg ? 2 : 0;
     const strategy: RenderStrategy = isImg ? 'vector' : classifyRenderStrategy(el, cs);
@@ -2440,6 +2446,7 @@ function buildInlineRunsWithLangFont(
           renderMode: 0,
           divisionDisable: el.hasAttribute('divisionDisable'),
           pageBreak: el.hasAttribute('pageBreak'),
+          href,
           imageId,
           objectFit: 0,
         });
@@ -2540,9 +2547,11 @@ function buildInlineRunsWithLangFont(
     if (overflowHidden) flags |= F_OVERFLOW;
     if (hasOpacity) flags |= F_OPACITY;
     if (isImg) flags |= F_IMAGE;
+    if (isImg) flags |= F_AVOID_IMAGE_SPLIT;
     if (renderMode !== 0) flags |= F_RENDER_MODE;
     if (divisionDisable) flags |= F_DIVISION_DISABLE;
     if (pageBreak) flags |= F_PAGE_BREAK;
+    if (href) flags |= F_LINK;
 
     const node: NodeRec = {
       id,
@@ -2565,6 +2574,7 @@ function buildInlineRunsWithLangFont(
       renderMode,
       divisionDisable,
       pageBreak,
+      href,
       imageId: isImg ? imgToId.get(el) : undefined,
       objectFit: isImg ? objectFitNum(cs.objectFit) : undefined,
     };
@@ -2898,7 +2908,7 @@ function writeOptWatermark(w: BinWriter, watermark: ResolvedWatermark | null) {
 function encode(a: EncodeArgs): Uint8Array {
   const w = new BinWriter();
   w.bytes(new Uint8Array([0x44, 0x32, 0x50, 0x31])); // "D2P1"
-  w.u32(10); // version 10 (adds image watermark support)
+  w.u32(11); // version 11 (adds hyperlink annotations)
   w.f32(a.pageWidthPt);
   w.f32(a.pageHeightPt);
   w.f32(a.mTop);
@@ -2970,6 +2980,7 @@ function encode(a: EncodeArgs): Uint8Array {
     if (n.renderMode !== 0) flags |= F_RENDER_MODE;
     if (n.divisionDisable) flags |= F_DIVISION_DISABLE;
     if (n.pageBreak) flags |= F_PAGE_BREAK;
+    if (n.href) flags |= F_LINK;
     w.u16(flags);
     if (n.bg) {
       w.f32(n.bg[0]); w.f32(n.bg[1]); w.f32(n.bg[2]); w.f32(n.bg[3]);
@@ -3011,6 +3022,11 @@ function encode(a: EncodeArgs): Uint8Array {
       w.u8(n.objectFit ?? 0);
     }
     if (n.renderMode !== 0) w.u8(n.renderMode);
+    if (n.href) {
+      const hrefLen = BinWriter.utf8Len(n.href);
+      w.u32(hrefLen);
+      w.utf8(n.href);
+    }
     if (n.kind === 1) {
       const text = n.text ?? '';
       const tlen = BinWriter.utf8Len(text);

--- a/wasm/src/paginate.rs
+++ b/wasm/src/paginate.rs
@@ -57,8 +57,14 @@ thread_local! {
 pub struct PagePlan {
     pub content: String,
     pub image_ids: Vec<u32>,
+    pub links: Vec<LinkAnnotation>,
     /// MediaBox height override (single-page mode); None = use pageHeightPt.
     pub media_h: Option<f32>,
+}
+
+pub struct LinkAnnotation {
+    pub href: String,
+    pub rect: [f32; 4],
 }
 
 fn precision() -> u8 {
@@ -735,6 +741,7 @@ pub fn paginate(
         pages.push(PagePlan {
             content,
             image_ids,
+            links: collect_page_links(snap, &geo, i, current_content_h_px, page_h_pt),
             media_h: single_media_h,
         });
     }
@@ -749,6 +756,47 @@ fn rect_pt(snap: &Snapshot, geo: &Geo, node: &Node, page: u32, content_h_px: f32
     let h = node.h * PX_TO_PT;
     let bottom = top_pt - h;
     (x0, bottom, w, h)
+}
+
+fn collect_page_links(
+    snap: &Snapshot,
+    geo: &Geo,
+    page: u32,
+    content_h_px: f32,
+    page_h_pt: f32,
+) -> Vec<LinkAnnotation> {
+    let band_top = page as f32 * content_h_px;
+    let band_bottom = band_top + content_h_px;
+    let content_left = snap.margin_left;
+    let content_right = snap.page_width_pt - snap.margin_right;
+    let mut links = Vec::new();
+
+    for node in snap.nodes.iter() {
+        let Some(href) = node.href.as_ref() else { continue };
+        if href.is_empty() || node.w <= 0.0 || node.h <= 0.0 || node.render_mode == 2 {
+            continue;
+        }
+        let top_px = node.y.max(band_top);
+        let bottom_px = (node.y + node.h).min(band_bottom);
+        if bottom_px <= top_px {
+            continue;
+        }
+
+        let x0 = (snap.margin_left + node.x * PX_TO_PT).max(content_left);
+        let x1 = (snap.margin_left + (node.x + node.w) * PX_TO_PT).min(content_right);
+        if x1 <= x0 {
+            continue;
+        }
+        let top = page_h_pt - snap.margin_top - geo.header_h_pt
+            - (top_px - band_top) * PX_TO_PT;
+        let bottom = page_h_pt - snap.margin_top - geo.header_h_pt
+            - (bottom_px - band_top) * PX_TO_PT;
+        links.push(LinkAnnotation {
+            href: href.clone(),
+            rect: [x0, bottom, x1, top],
+        });
+    }
+    links
 }
 
 fn find_image<'a>(snap: &'a Snapshot, image_id: u32) -> Option<&'a Image> {
@@ -1874,6 +1922,12 @@ pub fn build_pdf(
     let page_count = pages.len() as u32;
     let page_ids_first = w.alloc(page_count);
     let content_ids_first = w.alloc(page_count);
+    let annotation_count = pages.iter().map(|page| page.links.len() as u32).sum::<u32>();
+    let annotation_ids_first = if annotation_count > 0 {
+        w.alloc(annotation_count)
+    } else {
+        0
+    };
     let helvetica_first_id = w.alloc(4);
     let cid_count = fontctx.cid.len() as u32;
     // For each CID font: ToUnicode, FontFile2, FontDescriptor, CIDFont, Type0 = 5 objects.
@@ -2138,6 +2192,7 @@ pub fn build_pdf(
 
     // Page objects.
     let mut kids = String::new();
+    let mut next_annotation_id = annotation_ids_first;
     for i in 0..page_count {
         let pid = page_ids_first + i;
         let cid = content_ids_first + i;
@@ -2173,8 +2228,25 @@ pub fn build_pdf(
             extgstate.push_str(">> ");
         }
         let media_h = p.media_h.unwrap_or(snap.page_height_pt);
+        let mut annots = String::new();
+        if !p.links.is_empty() {
+            annots.push_str("/Annots [");
+            for link in p.links.iter() {
+                let annotation_id = next_annotation_id;
+                next_annotation_id += 1;
+                let rect = link.rect;
+                let uri = w.hex_string(annotation_id, link.href.as_bytes());
+                let annotation = format!(
+                    "<< /Type /Annot /Subtype /Link /Rect [{} {} {} {}] /Border [0 0 0] /A << /S /URI /URI {} >> >>",
+                    f(rect[0]), f(rect[1]), f(rect[2]), f(rect[3]), uri
+                );
+                w.indirect(annotation_id, &annotation);
+                annots.push_str(&format!("{} 0 R ", annotation_id));
+            }
+            annots.push_str("] ");
+        }
         let body = format!(
-            "<< /Type /Page /Parent {pages} 0 R /MediaBox [0 0 {pw} {ph}] /Resources << {font}{xobj}{extgstate}>> /Contents {cid} 0 R >>",
+            "<< /Type /Page /Parent {pages} 0 R /MediaBox [0 0 {pw} {ph}] /Resources << {font}{xobj}{extgstate}>> /Contents {cid} 0 R {annots}>>",
             pages = pages_id,
             pw = f(snap.page_width_pt),
             ph = f(media_h),
@@ -2182,6 +2254,7 @@ pub fn build_pdf(
             xobj = xobj,
             extgstate = extgstate,
             cid = cid,
+            annots = annots,
         );
         w.indirect(pid, &body);
         crate::emit_render_progress(i + 1, page_count);

--- a/wasm/src/pdf.rs
+++ b/wasm/src/pdf.rs
@@ -80,6 +80,17 @@ impl PdfWriter {
         self.end_obj();
     }
 
+    /// Encode a PDF string as hex, applying object-level encryption when enabled.
+    pub fn hex_string(&self, object_id: u32, value: &[u8]) -> String {
+        let bytes = if let Some(security) = &self.security {
+            security.encrypt_bytes(object_id, 0, value)
+        } else {
+            value.to_vec()
+        };
+        let hex = bytes.iter().map(|byte| format!("{:02X}", byte)).collect::<String>();
+        format!("<{}>", hex)
+    }
+
     pub fn write_encrypt_obj(&mut self) {
         if let (Some(security), Some(id)) = (self.security.as_ref(), self.encrypt_id) {
             let body = security.encrypt_dict();

--- a/wasm/src/snapshot.rs
+++ b/wasm/src/snapshot.rs
@@ -4,7 +4,7 @@
 //!
 //! Header:
 //!   magic: 4 bytes = "D2P1"
-//!   version: u32 = 10
+//!   version: u32 = 11
 //!   pageWidthPt, pageHeightPt, marginTop, marginRight, marginBottom, marginLeft: f32
 //!
 //! Config block:
@@ -161,6 +161,7 @@ pub struct Node {
     pub render_mode: u8,
     pub division_disable: bool,
     pub page_break: bool,
+    pub href: Option<String>,
     pub text: Option<String>,
     pub lines: Vec<Line>,
 }
@@ -177,6 +178,8 @@ pub const F_RENDER_MODE: u16 = 0x80;
 pub const F_DIVISION_DISABLE: u16 = 0x100;
 pub const F_PAGE_BREAK: u16 = 0x200;
 pub const F_SHADOW: u16 = 0x400;
+pub const F_LINK: u16 = 0x800;
+pub const F_AVOID_IMAGE_SPLIT: u16 = 0x1000;
 
 #[derive(Clone)]
 pub struct Border {
@@ -450,9 +453,9 @@ pub fn parse(data: &[u8]) -> Result<Snapshot, String> {
         return Err(format!("bad magic: {:?}", magic));
     }
     let version = c.u32()?;
-    if version != 7 && version != 8 && version != 9 && version != 10 {
+    if version != 7 && version != 8 && version != 9 && version != 10 && version != 11 {
         return Err(format!(
-            "unsupported version {} (expected 7, 8, 9 or 10)",
+            "unsupported version {} (expected 7, 8, 9, 10 or 11)",
             version
         ));
     }
@@ -643,6 +646,12 @@ pub fn parse(data: &[u8]) -> Result<Snapshot, String> {
         let render_mode = if flags & F_RENDER_MODE != 0 { c.u8()? } else { 0 };
         let division_disable = flags & F_DIVISION_DISABLE != 0;
         let page_break = flags & F_PAGE_BREAK != 0;
+        let href = if version >= 11 && flags & F_LINK != 0 {
+            let href_len = c.u32()? as usize;
+            Some(c.utf8(href_len)?)
+        } else {
+            None
+        };
         let mut text = None;
         let mut lines = Vec::new();
         if kind == 1 {
@@ -688,6 +697,7 @@ pub fn parse(data: &[u8]) -> Result<Snapshot, String> {
             render_mode,
             division_disable,
             page_break,
+            href,
             text,
             lines,
         });


### PR DESCRIPTION
## Summary

-  为 HTML 元素生成可点击的 PDF 超链接注解，并支持加密 PDF

## Testing

- [x] `npm test`
- [x] `npm run build`
- [x] Manual verification for affected example page(s)

## Notes

-
